### PR TITLE
T_VECTORS not being filled back after being popped

### DIFF
--- a/src/collider2d.ts
+++ b/src/collider2d.ts
@@ -155,6 +155,8 @@ export default class Collider2D {
 
       this._T_COLLISION_DETAILS.aInB = a.radius <= b.radius && dist <= b.radius - a.radius;
       this._T_COLLISION_DETAILS.bInA = b.radius <= a.radius && dist <= a.radius - b.radius;
+      
+      this._T_VECTORS.push(differenceV);
 
       return this._T_COLLISION_DETAILS;
     }


### PR DESCRIPTION
_T_VECTORS array needs an array to be pushed after being popped, otherwise it throws an error in the next call of any collision check. In the testCircleCircle function it pops a vector and doesn't push back another one.